### PR TITLE
Fixed certain Unity crashes

### DIFF
--- a/Core/2.Processing/Algorithms/MeshAlgorithms.cs
+++ b/Core/2.Processing/Algorithms/MeshAlgorithms.cs
@@ -130,7 +130,27 @@ namespace Chisel.Core
 				edgeIndices[i + 0] = index1;
 				edgeIndices[i + 1] = index2;
 			}
+			
             usedIndices.Dispose();
+		}
+		
+		public void RemoveDuplicates()
+		{
+			var cleaned = new NativeList<int>(positions2D.Length, Allocator.Temp);
+			var used = new NativeArray<bool>(positions2D.Length, Allocator.Temp);
+			for (int i = 0; i < positions2D.Length; i++)
+			{
+				if (!used[i])
+				{
+					cleaned.Add(lookup[i]);
+					used[i] = true;
+				}
+			}
+
+			lookup.Clear();
+			lookup.AddRange(cleaned);
+			cleaned.Dispose();
+			used.Dispose();
 		}
 
 		// Helper function to check if point q lies on segment pr (assuming p, q, r are collinear)

--- a/Core/2.Processing/Algorithms/MeshAlgorithms.cs
+++ b/Core/2.Processing/Algorithms/MeshAlgorithms.cs
@@ -307,7 +307,7 @@ namespace Chisel.Core
 			// Swap back
 			removeFlags.Dispose();
 			edgeIndices.Clear();
-			edgeIndices.AddRange(cleaned);
+			edgeIndices.AddRange(cleaned.AsArray());
 			cleaned.Dispose();
 		}
 

--- a/Core/2.Processing/Algorithms/MeshAlgorithms.cs
+++ b/Core/2.Processing/Algorithms/MeshAlgorithms.cs
@@ -148,7 +148,7 @@ namespace Chisel.Core
 			}
 
 			lookup.Clear();
-			lookup.AddRange(cleaned);
+			lookup.AddRange(cleaned.ToArray(Allocator.Temp));
 			cleaned.Dispose();
 			used.Dispose();
 		}

--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -5,10 +5,7 @@ using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
 using Unity.Mathematics;
 using Debug = UnityEngine.Debug;
-using Vector3 = UnityEngine.Vector3;
-using Quaternion = UnityEngine.Quaternion;
 using ReadOnlyAttribute = Unity.Collections.ReadOnlyAttribute;
-using WriteOnlyAttribute = Unity.Collections.WriteOnlyAttribute;
 using Unity.Entities;
 using andywiecko.BurstTriangulator.LowLevel.Unsafe;
 using andywiecko.BurstTriangulator;
@@ -210,8 +207,6 @@ namespace Chisel.Core
                     
                     var roVerts = vertex2DRemapper.AsReadOnly();
                     
-                    // TODO - check for self-intersections and split them
-
                     // Pre-check: need enough points and edges
                     if (roVerts.positions2D.Length < 3 || roVerts.edgeIndices.Length < 3)
                         continue;
@@ -316,12 +311,6 @@ namespace Chisel.Core
             if (brushRenderBufferCache[brushNodeOrder].IsCreated)
                 brushRenderBufferCache[brushNodeOrder].Dispose();
             brushRenderBufferCache[brushNodeOrder] = asset;
-        }
-        
-        [BurstDiscard]
-        static void LogException(Exception ex)
-        {
-            Debug.LogError($"Triangulator exception: {ex}");
         }
     }
 }

--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -11,8 +11,8 @@ using andywiecko.BurstTriangulator.LowLevel.Unsafe;
 using andywiecko.BurstTriangulator;
 
 namespace Chisel.Core
-{
-    // [BurstCompile(CompileSynchronously = true)]
+{ 
+    //[BurstCompile(CompileSynchronously = true)] // FIXME: If enabled, it causes more missing triangles in the mesh
     struct GenerateSurfaceTrianglesJob : IJobParallelForDefer
     {
         // Read

--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -202,13 +202,10 @@ namespace Chisel.Core
                     
                     if (vertex2DRemapper.CheckForSelfIntersections())
                     {
+#if UNITY_EDITOR && DEBUG
                         Debug.LogWarning($"Self-intersection detected in surface {surf}, loop index {loopIdx}.");
+#endif
                         vertex2DRemapper.RemoveSelfIntersectingEdges();
-                    }
-
-                    if (vertex2DRemapper.CheckForSelfIntersections())
-                    {
-                        Debug.LogWarning($"Self-intersection still detected in surface {surf}, loop index {loopIdx}.");
                     }
                     
                     var roVerts = vertex2DRemapper.AsReadOnly();
@@ -233,7 +230,7 @@ namespace Chisel.Core
                         settings,
                         Allocator.Temp);
                         
-#if UNITY_EDITOR
+#if UNITY_EDITOR && DEBUG
                     // Inside the loop after calling Triangulate:
                     if (output.Status.Value != Status.OK)
                     {
@@ -242,10 +239,10 @@ namespace Chisel.Core
                     }
                     else if (output.Triangles.Length == 0)
                     {
-                        Debug.LogWarning($"Triangulator returned zero triangles for surface {surf}, loop index {loopIdx}.");
+                        Debug.LogError($"Triangulator returned zero triangles for surface {surf}, loop index {loopIdx}.");
                     }
 #endif
-
+                    
                     if (output.Status.Value != Status.OK || output.Triangles.Length == 0)
                         continue;
 

--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -199,10 +199,11 @@ namespace Chisel.Core
                     // Convert 3D -> 2D
                     vertex2DRemapper.ConvertToPlaneSpace(*brushVertices.m_Vertices, edges, map3DTo2D);
                     
-                    if (!vertex2DRemapper.CheckForSelfIntersections())
+                    if (vertex2DRemapper.CheckForSelfIntersections())
                     {
                         Debug.LogError($"Self-intersection detected in loop {loopIdx} of surface {surf}");
                         // TODO - handle self-intersections
+                        vertex2DRemapper.RemoveSelfIntersectingEdges();
                     }
                     
                     var roVerts = vertex2DRemapper.AsReadOnly();

--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -201,9 +201,13 @@ namespace Chisel.Core
                     
                     if (vertex2DRemapper.CheckForSelfIntersections())
                     {
-                        Debug.LogError($"Self-intersection detected in loop {loopIdx} of surface {surf}");
-                        // TODO - handle self-intersections
+                        Debug.LogWarning($"Self-intersection detected in surface {surf}, loop index {loopIdx}.");
                         vertex2DRemapper.RemoveSelfIntersectingEdges();
+                    }
+
+                    if (vertex2DRemapper.CheckForSelfIntersections())
+                    {
+                        Debug.LogWarning($"Self-intersection still detected in surface {surf}, loop index {loopIdx}.");
                     }
                     
                     var roVerts = vertex2DRemapper.AsReadOnly();

--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -15,28 +15,26 @@ using andywiecko.BurstTriangulator;
 
 namespace Chisel.Core
 {
-    //[BurstCompile(CompileSynchronously = true)] // FIXME: For some reason causes infinite loop when burst compiled?
+    // [BurstCompile(CompileSynchronously = true)]
     struct GenerateSurfaceTrianglesJob : IJobParallelForDefer
     {
         // Read
-        // 'Required' for scheduling with index count
         [NoAlias, ReadOnly] public NativeList<IndexOrder>                           allUpdateBrushIndexOrders;
-        
         [NoAlias, ReadOnly] public NativeList<BlobAssetReference<BasePolygonsBlob>> basePolygonCache;
         [NoAlias, ReadOnly] public NativeList<NodeTransformations>                  transformationCache;
-        [NoAlias, ReadOnly] public NativeStream.Reader                              input;        
+        [NoAlias, ReadOnly] public NativeStream.Reader                              input;
         [NoAlias, ReadOnly] public NativeArray<MeshQuery>                           meshQueries;
 
         // Write
         [NativeDisableParallelForRestriction]
         [NoAlias] public NativeList<BlobAssetReference<ChiselBrushRenderBuffer>>    brushRenderBufferCache;
 
-        // Per thread scratch memory
+        // Scratch per-thread
         [NativeDisableContainerSafetyRestriction] HashedVertices                    brushVertices;
         [NativeDisableContainerSafetyRestriction] NativeList<UnsafeList<int>>       surfaceLoopIndices;
         [NativeDisableContainerSafetyRestriction] NativeArray<SurfaceInfo>          surfaceLoopAllInfos;
         [NativeDisableContainerSafetyRestriction] NativeList<UnsafeList<Edge>>      surfaceLoopAllEdges;
-        
+
         [BurstDiscard]
         public static void InvalidFinalCategory(CategoryIndex _interiorCategory)
         {
@@ -48,13 +46,11 @@ namespace Chisel.Core
             public readonly int Compare(ChiselQuerySurface x, ChiselQuerySurface y)
             {
                 var diff = x.surfaceParameter - y.surfaceParameter;
-                if (diff != 0)
-                    return diff;
+                if (diff != 0) return diff;
                 return x.surfaceIndex - y.surfaceIndex;
             }
         }
-
-        static readonly CompareSortByBasePlaneIndex compareSortByBasePlaneIndex = new CompareSortByBasePlaneIndex();
+        static readonly CompareSortByBasePlaneIndex compareSortByBasePlaneIndex = new();
 
         public unsafe void Execute(int index)
         {
@@ -62,257 +58,270 @@ namespace Chisel.Core
             if (count == 0)
                 return;
 
+            // Read brush data
             var brushIndexOrder = input.Read<IndexOrder>();
-            var brushNodeOrder = brushIndexOrder.nodeOrder;
-            var vertexCount = input.Read<int>();
+            var brushNodeOrder  = brushIndexOrder.nodeOrder;
+            var vertexCount     = input.Read<int>();
             NativeCollectionHelpers.EnsureCapacityAndClear(ref brushVertices, vertexCount);
             for (int v = 0; v < vertexCount; v++)
+                brushVertices.AddNoResize(input.Read<float3>());
+
+            // Pre-check: need at least 3 vertices
+            if (brushVertices.Length < 3)
             {
-                var vertex = input.Read<float3>();
-                brushVertices.AddNoResize(vertex);
+                input.EndForEachIndex();
+                return;
             }
 
+            // Read surface loops
             var surfaceOuterCount = input.Read<int>();
             NativeCollectionHelpers.EnsureSizeAndClear(ref surfaceLoopIndices, surfaceOuterCount);
             for (int o = 0; o < surfaceOuterCount; o++)
             {
                 UnsafeList<int> inner = default;
-                var surfaceInnerCount = input.Read<int>();
-                if (surfaceInnerCount > 0)
+                var countInner = input.Read<int>();
+                if (countInner > 0)
                 {
-                    inner = new UnsafeList<int>(surfaceInnerCount, Allocator.Temp);
-                    for (int i = 0; i < surfaceInnerCount; i++)
-                    {
+                    inner = new UnsafeList<int>(countInner, Allocator.Temp);
+                    for (int i = 0; i < countInner; i++)
                         inner.AddNoResize(input.Read<int>());
-                    }
                 }
                 surfaceLoopIndices[o] = inner;
             }
 
-            var surfaceLoopCount = input.Read<int>();
-            NativeCollectionHelpers.EnsureMinimumSizeAndClear(ref surfaceLoopAllInfos, surfaceLoopCount);
-            NativeCollectionHelpers.EnsureSizeAndClear(ref surfaceLoopAllEdges, surfaceLoopCount);
-            for (int l = 0; l < surfaceLoopCount; l++)
+            // Read loop infos and edges
+            var loopCount = input.Read<int>();
+            NativeCollectionHelpers.EnsureMinimumSizeAndClear(ref surfaceLoopAllInfos, loopCount);
+            NativeCollectionHelpers.EnsureSizeAndClear(ref surfaceLoopAllEdges, loopCount);
+            for (int l = 0; l < loopCount; l++)
             {
                 surfaceLoopAllInfos[l] = input.Read<SurfaceInfo>();
-                var edgeCount   = input.Read<int>();
+                var edgeCount = input.Read<int>();
                 if (edgeCount > 0)
-                { 
-                    var edgesInner  = new UnsafeList<Edge>(edgeCount, Allocator.Temp);
+                {
+                    var edges = new UnsafeList<Edge>(edgeCount, Allocator.Temp);
                     for (int e = 0; e < edgeCount; e++)
-                    {
-                        edgesInner.AddNoResize(input.Read<Edge>());
-                    }
-                    surfaceLoopAllEdges[l] = edgesInner;
+                        edges.AddNoResize(input.Read<Edge>());
+                    surfaceLoopAllEdges[l] = edges;
                 }
             }
             input.EndForEachIndex();
 
-
-
             if (!basePolygonCache[brushNodeOrder].IsCreated)
                 return;
 
-            var maxLoops = 0;
-            var maxIndices = 0;
+            // Compute maximum sizes
+            int maxLoops = 0, maxIndices = 0;
             for (int s = 0; s < surfaceLoopIndices.Length; s++)
             {
-                if (!surfaceLoopIndices[s].IsCreated)
-                    continue;
-                var length = surfaceLoopIndices[s].Length;
-                maxIndices += length;
-                maxLoops = math.max(maxLoops, length);
+                if (!surfaceLoopIndices[s].IsCreated) continue;
+                var len = surfaceLoopIndices[s].Length;
+                maxIndices += len;
+                maxLoops = math.max(maxLoops, len);
             }
-
 
             ref var baseSurfaces            = ref basePolygonCache[brushNodeOrder].Value.surfaces;
-            var brushTransformations        = transformationCache[brushNodeOrder];
-            var treeToNode                  = brushTransformations.treeToNode;
-            var nodeToTreeInverseTransposed = math.transpose(treeToNode);
-            
-			Vertex2DRemapper vertex2DRemapper = new()
-			{
-				lookup      = new NativeList<int>(64, Allocator.Temp),
-				positions2D = new NativeList<double2>(64, Allocator.Temp),
-				edgeIndices = new NativeList<int>(128, Allocator.Temp)
-			};
-			UniqueVertexMapper uniqueVertexMapper = new()
+            var transform                    = transformationCache[brushNodeOrder];
+            var treeToNode                   = transform.treeToNode;
+            var nodeToTreeInvTrans          = math.transpose(treeToNode);
+
+            // Scratch allocators
+            var vertex2DRemapper = new Vertex2DRemapper
             {
-				indexRemap = new NativeArray<int>(brushVertices.Length, Allocator.Temp),
-                surfaceColliderVertices = new NativeList<float3>(brushVertices.Length, Allocator.Temp),
-				surfaceRenderVertices = new NativeList<RenderVertex>(brushVertices.Length, Allocator.Temp)
+                lookup      = new NativeList<int>(64, Allocator.Temp),
+                positions2D = new NativeList<double2>(64, Allocator.Temp),
+                edgeIndices = new NativeList<int>(128, Allocator.Temp)
+            };
+            var uniqueVertexMapper = new UniqueVertexMapper
+            {
+                indexRemap               = new NativeArray<int>(brushVertices.Length, Allocator.Temp),
+                surfaceColliderVertices  = new NativeList<float3>(brushVertices.Length, Allocator.Temp),
+                surfaceRenderVertices    = new NativeList<RenderVertex>(brushVertices.Length, Allocator.Temp)
             };
 
-            Args settings = new(
-                    autoHolesAndBoundary: true,
-                    concentricShellsParameter: 0.001f,
-                    preprocessor: andywiecko.BurstTriangulator.Preprocessor.None,
-                    refineMesh: false,
-                    restoreBoundary: true,
-                    sloanMaxIters: 1_000_000,
-                    validateInput: true,
-                    verbose: true,
-                    refinementThresholdAngle: math.radians(5),
-                    refinementThresholdArea: 1f
-				);
+            // Configure triangulation settings
+            var settings = new Args(
+                autoHolesAndBoundary:       true,
+                concentricShellsParameter:  0.001f,
+                preprocessor:               Preprocessor.None,
+                refineMesh:                 false,
+                restoreBoundary:            true,
+                sloanMaxIters:              1_000_000,
+                validateInput:              true,
+                verbose:                    true,
+                refinementThresholdAngle:   math.radians(5),
+                refinementThresholdArea:    1f
+            );
 
-			var surfaceIndexList = new NativeList<int>(maxIndices, Allocator.Temp);
-            var loops = new NativeList<int>(maxLoops, Allocator.Temp);
+            var surfaceIndexList = new NativeList<int>(maxIndices, Allocator.Temp);
+            var loops            = new NativeList<int>(maxLoops, Allocator.Temp);
 
-			//var outputPositions = new NativeList<double2>(64, Allocator.Temp);
-			var output = new andywiecko.BurstTriangulator.LowLevel.Unsafe.OutputData<double2>()
-			{
-				//Positions = outputPositions,
-				Triangles = new NativeList<int>(64, Allocator.Temp),
-                Status = new NativeReference<Status>(Allocator.Temp)
-			};
-			var triangulator = new UnsafeTriangulator<double2>();
-
-			var builder = new BlobBuilder(Allocator.Temp, 4096);
-            ref var root = ref builder.ConstructRoot<ChiselBrushRenderBuffer>();
-            var surfaceRenderBuffers = builder.Allocate(ref root.surfaces, surfaceLoopIndices.Length);
-
-			for (int surfaceIndex = 0; surfaceIndex < surfaceLoopIndices.Length; surfaceIndex++)
+            var output = new andywiecko.BurstTriangulator.LowLevel.Unsafe.OutputData<double2>
             {
-                if (!surfaceLoopIndices[surfaceIndex].IsCreated)
-                    continue;
+                Triangles = new NativeList<int>(64, Allocator.Temp),
+                Status    = new NativeReference<Status>(Allocator.Temp)
+            };
+            var triangulator = new UnsafeTriangulator<double2>();
 
-                loops.Clear();
-                uniqueVertexMapper.Reset();
+            var builder = new BlobBuilder(Allocator.Temp, 4096);
+            ref var root = ref builder.ConstructRoot<ChiselBrushRenderBuffer>();
+            var surfaceBuffers = builder.Allocate(ref root.surfaces, surfaceLoopIndices.Length);
 
-				var loopIndices = surfaceLoopIndices[surfaceIndex];
-                for (int l = 0; l < loopIndices.Length; l++)
+            // Process each surface
+            for (int surf = 0; surf < surfaceLoopIndices.Length; surf++)
+            {
+                if (!surfaceLoopIndices[surf].IsCreated) continue;
+                loops.Clear(); uniqueVertexMapper.Reset();
+
+                // Collect valid loops
+                var loopIndices = surfaceLoopIndices[surf];
+                for (int i = 0; i < loopIndices.Length; i++)
                 {
-                    var surfaceLoopIndex    = loopIndices[l];
-                    var surfaceLoopEdges    = surfaceLoopAllEdges[surfaceLoopIndex];
+                    var loopIdx = loopIndices[i];
+                    var edges   = surfaceLoopAllEdges[loopIdx];
+                    if (edges.Length < 3) continue;
+                    loops.AddNoResize(loopIdx);
+                }
+                if (loops.Length == 0) continue;
 
-                    // TODO: verify that this never happens, check should be in previous job
-                    Debug.Assert(surfaceLoopEdges.Length >= 3);
-                    if (surfaceLoopEdges.Length < 3)
+                // Setup plane-space mapping
+                var plane           = baseSurfaces[surf].localPlane;
+                var localToPlane    = MathExtensions.GenerateLocalToPlaneSpaceMatrix(plane);
+                var treeToPlane     = math.mul(localToPlane, treeToNode);
+                var planeNormalMap  = math.mul(nodeToTreeInvTrans, plane);
+                var map3DTo2D       = new Map3DTo2D(planeNormalMap.xyz);
+
+                surfaceIndexList.Clear();
+                for (int li = 0; li < loops.Length; li++)
+                {
+                    var loopIdx  = loops[li];
+                    var edges    = surfaceLoopAllEdges[loopIdx];
+                    var info     = surfaceLoopAllInfos[loopIdx];
+                    Debug.Assert(surf == info.basePlaneIndex, "surfaceIndex mismatch");
+
+                    // Convert 3D -> 2D
+                    vertex2DRemapper.ConvertToPlaneSpace(*brushVertices.m_Vertices, edges, map3DTo2D);
+                    
+                    if (!vertex2DRemapper.CheckForSelfIntersections())
+                    {
+                        Debug.LogError($"Self-intersection detected in loop {loopIdx} of surface {surf}");
+                        // TODO - handle self-intersections
+                    }
+                    
+                    var roVerts = vertex2DRemapper.AsReadOnly();
+                    
+                    // TODO - check for self-intersections and split them
+
+                    // Pre-check: need enough points and edges
+                    if (roVerts.positions2D.Length < 3 || roVerts.edgeIndices.Length < 3)
                         continue;
 
-                    loops.Add(surfaceLoopIndex);
+                    // Triangulate with exception guard
+                    output.Triangles.Clear();
+                    triangulator.Triangulate(
+                        new andywiecko.BurstTriangulator.LowLevel.Unsafe.InputData<double2>
+                        {
+                            Positions = roVerts.positions2D, 
+                            ConstraintEdges = roVerts.edgeIndices
+                        },
+                        output,
+                        settings,
+                        Allocator.Temp);
+                        
+#if UNITY_EDITOR
+                    // Inside the loop after calling Triangulate:
+                    if (output.Status.Value != Status.OK)
+                    {
+                        // Log the specific status enum value/name for more detail!
+                        Debug.LogError($"Triangulator failed for surface {surf}, loop index {loopIdx} with status {output.Status.Value.ToString()} ({output.Status.Value})");
+                    }
+                    else if (output.Triangles.Length == 0)
+                    {
+                        Debug.LogWarning($"Triangulator returned zero triangles for surface {surf}, loop index {loopIdx}.");
+                    }
+#endif
+
+                    if (output.Status.Value != Status.OK || output.Triangles.Length == 0)
+                        continue;
+
+                    // Map triangles back
+                    var prevCount = surfaceIndexList.Length;
+                    var interiorCat = (CategoryIndex)info.interiorCategory;
+                    roVerts.RemapTriangles(interiorCat, output.Triangles, surfaceIndexList);
+                    uniqueVertexMapper.RegisterVertices(
+                        surfaceIndexList,
+                        prevCount,
+                        *brushVertices.m_Vertices,
+                        map3DTo2D.normal,
+                        interiorCat);
                 }
 
-                if (loops.Length == 0)
-                    continue;
-                
-				// We need to convert our UV matrix from tree-space, to brush local-space, to plane-space
-                // since the vertices of the polygons, at this point, are in tree-space.
-                var localSpacePlane         = baseSurfaces[surfaceIndex].localPlane;
-				var localSpaceToPlaneSpace  = MathExtensions.GenerateLocalToPlaneSpaceMatrix(localSpacePlane);
-                var treeSpaceToPlaneSpace   = math.mul(localSpaceToPlaneSpace, treeToNode);
-                var surfaceTreeSpacePlane   = math.mul(nodeToTreeInverseTransposed, localSpacePlane);
-				var map3DTo2D               = new Map3DTo2D(surfaceTreeSpacePlane.xyz);
+                if (surfaceIndexList.Length == 0) continue;
 
+                // Finalize mesh data
+                var flags  = baseSurfaces[surf].destinationFlags;
+                var parms  = baseSurfaces[surf].destinationParameters;
+                var UV0    = baseSurfaces[surf].UV0;
+                var uvMat  = math.mul(UV0.ToFloat4x4(), treeToPlane);
+                MeshAlgorithms.ComputeUVs(uniqueVertexMapper.surfaceRenderVertices, uvMat);
+                MeshAlgorithms.ComputeTangents(surfaceIndexList, uniqueVertexMapper.surfaceRenderVertices);
 
-				surfaceIndexList.Clear();
-                for (int l = 0; l < loops.Length; l++)
-                {
-                    var loopIndex   = loops[l];
-                    var loopEdges   = surfaceLoopAllEdges[loopIndex];
-                    var loopInfo    = surfaceLoopAllInfos[loopIndex];
-					Debug.Assert(surfaceIndex == loopInfo.basePlaneIndex, "surfaceIndex != loopInfo.basePlaneIndex");
+                ref var buf = ref surfaceBuffers[surf];
+                buf.Construct(
+                    builder,
+                    surfaceIndexList,
+                    uniqueVertexMapper.surfaceRenderVertices,
+                    uniqueVertexMapper.surfaceColliderVertices,
+                    surf,
+                    flags,
+                    parms);
+            }
 
-					#region Map 3D polygon to 2D surface
-					vertex2DRemapper.ConvertToPlaneSpace(*brushVertices.m_Vertices, loopEdges, map3DTo2D);
-                    var readOnlyVertices = vertex2DRemapper.AsReadOnly();
-					#endregion
+            // Clean up
+            output.Triangles.Dispose(); output.Status.Dispose();
+            uniqueVertexMapper.Dispose(); vertex2DRemapper.Dispose();
+            surfaceIndexList.Dispose(); loops.Dispose();
 
-					#region Triangulate
-					output.Triangles.Clear();
-                    var input = new andywiecko.BurstTriangulator.LowLevel.Unsafe.InputData<double2>()
-                    {
-                        Positions = readOnlyVertices.positions2D,
-                        ConstraintEdges = readOnlyVertices.edgeIndices
-                    };
-					triangulator.Triangulate(input, output, settings, Allocator.Temp);
-                    if (output.Status.Value != andywiecko.BurstTriangulator.Status.OK) { Debug.LogError($"{output.Status.Value}"); continue; }
-                    if (output.Triangles.Length == 0) continue;
-					#endregion
-
-					#region Add triangles to surface
-					var prevSurfaceIndexCount = surfaceIndexList.Length;
-					CategoryIndex interiorCategory = (CategoryIndex)loopInfo.interiorCategory;
-					readOnlyVertices.RemapTriangles(interiorCategory, output.Triangles, surfaceIndexList);
-                    uniqueVertexMapper.RegisterVertices(surfaceIndexList, prevSurfaceIndexCount, *brushVertices.m_Vertices, map3DTo2D.normal, interiorCategory);
-					#endregion
-				}
-
-				if (surfaceIndexList.Length == 0)
-                    continue;
-				
-                var destinationFlags      = baseSurfaces[surfaceIndex].destinationFlags;
-                var destinationParameters = baseSurfaces[surfaceIndex].destinationParameters;
-                var UV0                   = baseSurfaces[surfaceIndex].UV0;
-
-				var uv0Matrix = math.mul(UV0.ToFloat4x4(), treeSpaceToPlaneSpace);
-				MeshAlgorithms.ComputeUVs(uniqueVertexMapper.surfaceRenderVertices, uv0Matrix);
-				MeshAlgorithms.ComputeTangents(surfaceIndexList, uniqueVertexMapper.surfaceRenderVertices);
-
-				ref var surfaceRenderBuffer = ref surfaceRenderBuffers[surfaceIndex];
-                surfaceRenderBuffer.Construct(builder, surfaceIndexList, uniqueVertexMapper.surfaceRenderVertices,
-											  uniqueVertexMapper.surfaceColliderVertices, surfaceIndex, 
-                                              destinationFlags, destinationParameters);
-			}
-
-			//triangulator.Dispose();
-			output.Triangles.Dispose();
-            output.Status.Dispose();
-			uniqueVertexMapper.Dispose();
-			vertex2DRemapper.Dispose();
-            surfaceIndexList.Dispose();
-            loops.Dispose();
-
-			var querySurfaceList = new NativeList<ChiselQuerySurface>(surfaceRenderBuffers.Length, Allocator.Temp);			
-            var querySurfaces = builder.Allocate(ref root.querySurfaces, meshQueries.Length);
-            for (int t = 0; t < meshQueries.Length; t++)
+            // Build query surfaces...
+            var queryList = new NativeList<ChiselQuerySurface>(surfaceBuffers.Length, Allocator.Temp);
+            var queryArr  = builder.Allocate(ref root.querySurfaces, meshQueries.Length);
+            for (int i = 0; i < meshQueries.Length; i++)
             {
-                var meshQuery       = meshQueries[t];
-                var layerQueryMask  = meshQuery.LayerQueryMask;
-                var layerQuery      = meshQuery.LayerQuery;
-                var surfaceParameterIndex = (meshQuery.LayerParameterIndex >= SurfaceParameterIndex.Parameter1 && 
-                                             meshQuery.LayerParameterIndex <= SurfaceParameterIndex.MaxParameterIndex) ?
-                                             (int)meshQuery.LayerParameterIndex - 1 : -1;
-
-                querySurfaceList.Clear();
-
-                for (int s = 0; s < surfaceRenderBuffers.Length; s++)
+                var mq = meshQueries[i];
+                queryList.Clear();
+                for (int s = 0; s < surfaceBuffers.Length; s++)
                 {
-					ref var renderBuffer = ref surfaceRenderBuffers[s];
-					var destinationFlags  = renderBuffer.destinationFlags;
-                    if ((destinationFlags & layerQueryMask) != layerQuery)
-                        continue;
-
-					querySurfaceList.AddNoResize(new ChiselQuerySurface
+                    ref var rb = ref surfaceBuffers[s];
+                    if ((rb.destinationFlags & mq.LayerQueryMask) != mq.LayerQuery) continue;
+                    queryList.AddNoResize(new ChiselQuerySurface
                     {
-                        surfaceIndex        = renderBuffer.surfaceIndex,
-                        surfaceParameter    = surfaceParameterIndex < 0 ? 0 : renderBuffer.destinationParameters.parameters[surfaceParameterIndex],
-                        vertexCount         = renderBuffer.vertexCount,
-                        indexCount          = renderBuffer.indexCount,
-                        surfaceHash         = renderBuffer.surfaceHash,
-                        geometryHash        = renderBuffer.geometryHash
+                        surfaceIndex     = rb.surfaceIndex,
+                        surfaceParameter = rb.destinationParameters.parameters[Math.Max(0, (int)mq.LayerParameterIndex-1)],
+                        vertexCount      = rb.vertexCount,
+                        indexCount       = rb.indexCount,
+                        surfaceHash      = rb.surfaceHash,
+                        geometryHash     = rb.geometryHash
                     });
                 }
-                querySurfaceList.Sort(compareSortByBasePlaneIndex);
-
-                builder.Construct(ref querySurfaces[t].surfaces, querySurfaceList);
-                querySurfaces[t].brushNodeID = brushIndexOrder.compactNodeID;
+                queryList.Sort(compareSortByBasePlaneIndex);
+                builder.Construct(ref queryArr[i].surfaces, queryList);
+                queryArr[i].brushNodeID = brushIndexOrder.compactNodeID;
             }
+            queryList.Dispose();
 
-            querySurfaceList.Dispose();
-
-
-			root.surfaceOffset = 0;
-            root.surfaceCount = surfaceRenderBuffers.Length;
-
-            var brushRenderBuffer = builder.CreateBlobAssetReference<ChiselBrushRenderBuffer>(Allocator.Persistent);
+            // Create or replace blob asset
+            root.surfaceOffset = 0;
+            root.surfaceCount  = surfaceBuffers.Length;
+            var asset = builder.CreateBlobAssetReference<ChiselBrushRenderBuffer>(Allocator.Persistent);
             if (brushRenderBufferCache[brushNodeOrder].IsCreated)
-            {
                 brushRenderBufferCache[brushNodeOrder].Dispose();
-                brushRenderBufferCache[brushNodeOrder] = default;
-            }
-            brushRenderBufferCache[brushNodeOrder] = brushRenderBuffer;
+            brushRenderBufferCache[brushNodeOrder] = asset;
+        }
+        
+        [BurstDiscard]
+        static void LogException(Exception ex)
+        {
+            Debug.LogError($"Triangulator exception: {ex}");
         }
     }
 }

--- a/Core/2.Processing/Jobs/PerformCSGJob.cs
+++ b/Core/2.Processing/Jobs/PerformCSGJob.cs
@@ -270,10 +270,12 @@ namespace Chisel.Core
                         intersectedHoleIndices[intersectedHoleIndicesLength] = allEdges.Length;
                         intersectedHoleIndicesLength++;
                         holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                        //if (allInfos.Capacity < allInfos.Length + 1)
-                        //    allInfos.Capacity = allInfos.Length + 16;
-                        //allInfos.AddNoResize(holeInfo);
-                        allInfos.Add(holeInfo);
+                        
+                        if (allInfos.Capacity < allInfos.Length + 1)
+                            // e.g. double the capacity (or add a fixed extra)
+                            allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
+                        allInfos.AddNoResize(holeInfo);
+                        
                         var newHoleEdges = new UnsafeList<Edge>(holeEdges.Length, Allocator.Temp);
                         newHoleEdges.AddRangeNoResize(holeEdges);
                         allEdges.Add(newHoleEdges);
@@ -290,10 +292,12 @@ namespace Chisel.Core
                 currentHoleIndices.Add(allEdges.Length);
                 holeIndices[surfaceLoopIndex] = currentHoleIndices;
                 holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                //if (allInfos.Capacity < allInfos.Length + 1)
-                //    allInfos.Capacity = allInfos.Length + 16; 
-                //allInfos.AddNoResize(intersectionInfo);
-                allInfos.Add(intersectionInfo);
+                
+                if (allInfos.Capacity < allInfos.Length + 1)
+                    // e.g. double the capacity (or add a fixed extra)
+                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
+                allInfos.AddNoResize(intersectionInfo);
+                
                 var newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -309,10 +313,12 @@ namespace Chisel.Core
                 var newHoleIndices = new UnsafeList<int>(intersectedHoleIndicesLength, Allocator.Temp);
                 newHoleIndices.AddRangeNoResize(intersectedHoleIndices, intersectedHoleIndicesLength);
                 holeIndices.Add(newHoleIndices);
-                //if (allInfos.Capacity < allInfos.Length + 1)
-                //    allInfos.Capacity = allInfos.Length + 16; 
-                //allInfos.AddNoResize(intersectionInfo);
+                
+                if (allInfos.Capacity < allInfos.Length + 1)
+                    // e.g. double the capacity (or add a fixed extra)
+                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
                 allInfos.Add(intersectionInfo);
+                
                 newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -326,10 +332,12 @@ namespace Chisel.Core
                 currentHoleIndices.Add(allEdges.Length);
                 holeIndices[surfaceLoopIndex] = currentHoleIndices;
                 holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                //if (allInfos.Capacity < allInfos.Length + 1)
-                //    allInfos.Capacity = allInfos.Length + 16;
-                //allInfos.AddNoResize(intersectionInfo);
-                allInfos.Add(intersectionInfo);
+                
+                if (allInfos.Capacity < allInfos.Length + 1)
+                    // e.g. double the capacity (or add a fixed extra)
+                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
+                allInfos.AddNoResize(intersectionInfo);
+                
                 var newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -343,9 +351,12 @@ namespace Chisel.Core
                 //loopIndices.AddNoResize(allEdges.Length);
                 loopIndices.Add(allEdges.Length);
                 holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
+                
                 if (allInfos.Capacity < allInfos.Length + 1)
-                    allInfos.Capacity = allInfos.Length + 16;
+                    // e.g. double the capacity (or add a fixed extra)
+                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
                 allInfos.AddNoResize(intersectionInfo);
+
                 newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -906,7 +917,8 @@ namespace Chisel.Core
             }
 
 
-            var maxLoops            = (routingLookupsLength + routingLookupsLength) * (surfaceCount + surfaceCount); // TODO: find a more reliable "max"
+            var maxLoops = routingLookupsLength * (surfaceCount + surfaceCount) * 4; 
+            // TODO: find a more reliable "max"
 
             NativeCollectionHelpers.EnsureCapacityAndClear(ref holeIndices, maxLoops);
             NativeCollectionHelpers.EnsureSizeAndClear(ref surfaceLoopIndices, surfaceCount);

--- a/Core/2.Processing/Jobs/PerformCSGJob.cs
+++ b/Core/2.Processing/Jobs/PerformCSGJob.cs
@@ -270,12 +270,10 @@ namespace Chisel.Core
                         intersectedHoleIndices[intersectedHoleIndicesLength] = allEdges.Length;
                         intersectedHoleIndicesLength++;
                         holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                        
-                        if (allInfos.Capacity < allInfos.Length + 1)
-                            // e.g. double the capacity (or add a fixed extra)
-                            allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
-                        allInfos.AddNoResize(holeInfo);
-                        
+                        //if (allInfos.Capacity < allInfos.Length + 1)
+                        //    allInfos.Capacity = allInfos.Length + 16;
+                        //allInfos.AddNoResize(holeInfo);
+                        allInfos.Add(holeInfo);
                         var newHoleEdges = new UnsafeList<Edge>(holeEdges.Length, Allocator.Temp);
                         newHoleEdges.AddRangeNoResize(holeEdges);
                         allEdges.Add(newHoleEdges);
@@ -292,12 +290,10 @@ namespace Chisel.Core
                 currentHoleIndices.Add(allEdges.Length);
                 holeIndices[surfaceLoopIndex] = currentHoleIndices;
                 holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                
-                if (allInfos.Capacity < allInfos.Length + 1)
-                    // e.g. double the capacity (or add a fixed extra)
-                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
-                allInfos.AddNoResize(intersectionInfo);
-                
+                //if (allInfos.Capacity < allInfos.Length + 1)
+                //    allInfos.Capacity = allInfos.Length + 16; 
+                //allInfos.AddNoResize(intersectionInfo);
+                allInfos.Add(intersectionInfo);
                 var newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -313,12 +309,10 @@ namespace Chisel.Core
                 var newHoleIndices = new UnsafeList<int>(intersectedHoleIndicesLength, Allocator.Temp);
                 newHoleIndices.AddRangeNoResize(intersectedHoleIndices, intersectedHoleIndicesLength);
                 holeIndices.Add(newHoleIndices);
-                
-                if (allInfos.Capacity < allInfos.Length + 1)
-                    // e.g. double the capacity (or add a fixed extra)
-                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
+                //if (allInfos.Capacity < allInfos.Length + 1)
+                //    allInfos.Capacity = allInfos.Length + 16; 
+                //allInfos.AddNoResize(intersectionInfo);
                 allInfos.Add(intersectionInfo);
-                
                 newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -332,12 +326,10 @@ namespace Chisel.Core
                 currentHoleIndices.Add(allEdges.Length);
                 holeIndices[surfaceLoopIndex] = currentHoleIndices;
                 holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                
-                if (allInfos.Capacity < allInfos.Length + 1)
-                    // e.g. double the capacity (or add a fixed extra)
-                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
-                allInfos.AddNoResize(intersectionInfo);
-                
+                //if (allInfos.Capacity < allInfos.Length + 1)
+                //    allInfos.Capacity = allInfos.Length + 16;
+                //allInfos.AddNoResize(intersectionInfo);
+                allInfos.Add(intersectionInfo);
                 var newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -351,12 +343,9 @@ namespace Chisel.Core
                 //loopIndices.AddNoResize(allEdges.Length);
                 loopIndices.Add(allEdges.Length);
                 holeIndices.Add(new UnsafeList<int>(1, Allocator.Temp));
-                
                 if (allInfos.Capacity < allInfos.Length + 1)
-                    // e.g. double the capacity (or add a fixed extra)
-                    allInfos.Capacity = math.max(allInfos.Capacity * 2, allInfos.Length + 1);
+                    allInfos.Capacity = allInfos.Length + 16;
                 allInfos.AddNoResize(intersectionInfo);
-
                 newOutEdges = new UnsafeList<Edge>(outEdgesLength, Allocator.Temp);
                 newOutEdges.AddRangeNoResize(outEdges, outEdgesLength);
                 allEdges.Add(newOutEdges);
@@ -917,8 +906,7 @@ namespace Chisel.Core
             }
 
 
-            var maxLoops = routingLookupsLength * (surfaceCount + surfaceCount) * 4; 
-            // TODO: find a more reliable "max"
+            var maxLoops            = (routingLookupsLength + routingLookupsLength) * (surfaceCount + surfaceCount); // TODO: find a more reliable "max"
 
             NativeCollectionHelpers.EnsureCapacityAndClear(ref holeIndices, maxLoops);
             NativeCollectionHelpers.EnsureSizeAndClear(ref surfaceLoopIndices, surfaceCount);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.chisel",
   "displayName": "Chisel 3D Level Editor",
-  "version": "0.3.0-preview",
+  "version": "0.3.1-preview",
   "unity": "6000.0",
   "description": "A boolean (CSG) based 3d level editor for Unity",
   "license": "MIT",
@@ -16,9 +16,9 @@
      }
   ],
   "dependencies": {
-    "com.unity.burst": "1.8.17",
-    "com.unity.entities": "1.2.4",
-    "com.unity.collections": "2.4.3",
+    "com.unity.burst": "1.8.21",
+    "com.unity.entities": "1.3.14",
+    "com.unity.collections": "2.5.7",
     "com.unity.mathematics": "1.3.2",
     "com.unity.profiling.core": "1.0.2"
   }


### PR DESCRIPTION
This fixes several issues that cause crashes in Unity.
While there's additional logging for self-intersecting polygons, this issue is not yet fixed.

It doesn't crash anymore when you burst compile GenerateSurfaceTrianglesJob, but it's somehow slower and causes missing faces.