### PR TITLE
Fixed UVs not generated on model

### DIFF
--- a/Components/Managers/ChiselModelManager.cs
+++ b/Components/Managers/ChiselModelManager.cs
@@ -209,7 +209,6 @@ namespace Chisel.Components
 			if(model.AutoRebuildUVs)
 			{
 				ForceUpdateDelayedUVGeneration();
-				DelayedUVGeneration(force: true);
 			}
 		}
 

--- a/Components/Managers/ChiselModelManager.cs
+++ b/Components/Managers/ChiselModelManager.cs
@@ -205,6 +205,12 @@ namespace Chisel.Components
 			}
 
 			UpdateModelFlags(model);
+
+			if(model.AutoRebuildUVs)
+			{
+				ForceUpdateDelayedUVGeneration();
+				DelayedUVGeneration(force: true);
+			}
 		}
 
 		public bool IsDefaultModel(UnityEngine.Object obj)


### PR DESCRIPTION
The UVs were somehow not generated on a model with Auto UV Generation turned on, causing baked lightmaps to be incorrect. 
I put in this hack and it fixed the problem for me.