### PR TITLE
Fixed Unity 6.3 Burst Compilation

### DIFF
--- a/Core/1.Input/CompactHierarchy/CompactHierarchy.Internal.cs
+++ b/Core/1.Input/CompactHierarchy/CompactHierarchy.Internal.cs
@@ -333,7 +333,8 @@ namespace Chisel.Core
             };
             if (nodeInformation.brushMeshHash != 0 &&
                 nodeInformation.brushMeshHash != Int32.MaxValue)
-                brushMeshToBrush.Add(nodeInformation.brushMeshHash, compactNodeID);
+                brushMeshToBrush.TryAdd(nodeInformation.brushMeshHash, compactNodeID);
+
             Debug.Assert(IsValidCompactNodeID(compactNodeID), "newly created ID is invalid");
             Debug.Assert(GetChildRef(compactNodeID).instanceID == nodeInformation.instanceID, "newly created ID is invalid");
             return compactNodeID;
@@ -359,7 +360,8 @@ namespace Chisel.Core
             BrushMeshManager.RegisterBrushMeshHash(ref brushMeshBlobCache, newBrushMeshHash, prevBrushMeshHash);
             if (newBrushMeshHash != 0 && 
                 newBrushMeshHash != Int32.MaxValue)
-                brushMeshToBrush.Add(newBrushMeshHash, compactNodeID);
+                brushMeshToBrush.TryAdd(newBrushMeshHash, compactNodeID);
+
 
             if (compactNode.nodeInformation.brushMeshHash != newBrushMeshHash)
                 compactNode.nodeInformation.brushMeshHash = newBrushMeshHash;

--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
   "type": "tool",
   "hideInEditor": false,
   "samples": [
-     {
-       "displayName": "Sample scene",
-       "description": "A sample scene made in Chisel",
-       "path": "Samples~/Sample Scene"
-     }
+    {
+      "displayName": "Sample scene",
+      "description": "A sample scene made in Chisel",
+      "path": "Samples~/Sample Scene"
+    }
   ],
   "dependencies": {
-    "com.unity.burst": "1.8.21",
-    "com.unity.entities": "1.3.14",
-    "com.unity.collections": "2.5.7",
-    "com.unity.mathematics": "1.3.2",
-    "com.unity.profiling.core": "1.0.2"
+    "com.unity.burst": "1.8.26",
+    "com.unity.entities": "1.4.3",
+    "com.unity.collections": "2.6.3",
+    "com.unity.mathematics": "1.3.3",
+    "com.unity.profiling.core": "1.0.3"
   }
 }


### PR DESCRIPTION
In Unity 6.3 the compilation causes some issues. Switching from `brushMeshToBrush.Add `to `brushMeshToBrush.TryAdd` fixes the issues.